### PR TITLE
Added github repo to dist metadata and some other dist improvements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,10 +1,14 @@
-Revision history for Spreadsheet-HTML
+Revision history for Perl module Spreadsheet::HTML
 
-0.05
+0.05 2015-05-??
+    - Adjusted formatting of this file to match CPAN::Changes::Spec
 
-0.04    Temporarily allowing DBIx::HTML to subclass.
+0.04 2015-05-16 JEFFA
+    - Temporarily allowing DBIx::HTML to subclass.
 
-0.03    Major refactoring, able to transpose.
+0.03 2015-05-16 JEFFA
+    - Major refactoring, able to transpose.
 
-0.02    First version, released on an unsuspecting world.
+0.02 2015-05-16 JEFFA
+    - First version, released on an unsuspecting world.
 

--- a/Changes
+++ b/Changes
@@ -1,9 +1,11 @@
 Revision history for Perl module Spreadsheet::HTML
 
-0.05 2015-05-??
+0.05 2015-05-?? JEFFA
     - Added github repo to the dist's metadata
     - Changed license metadata setting from 'Artistic_2_0' to 'artistic_2',
       which is what CPAN::Meta::Spec expects.
+    - Set PREREQ_PM, TEST_REQUIRES, CONFIGURE_REQUIRES appropriately
+      depending on local version of ExtUtils::MakeMaker.
     - Adjusted formatting of this file to match CPAN::Changes::Spec
 
 0.04 2015-05-16 JEFFA

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Spreadsheet::HTML
 
 0.05 2015-05-??
+    - Added github repo to the dist's metadata
     - Adjusted formatting of this file to match CPAN::Changes::Spec
 
 0.04 2015-05-16 JEFFA

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl module Spreadsheet::HTML
 
 0.05 2015-05-??
     - Added github repo to the dist's metadata
+    - Changed license metadata setting from 'Artistic_2_0' to 'artistic_2',
+      which is what CPAN::Meta::Spec expects.
     - Adjusted formatting of this file to match CPAN::Changes::Spec
 
 0.04 2015-05-16 JEFFA

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,16 @@
+Changes
+lib/Spreadsheet/HTML.pm
+Makefile.PL
+MANIFEST
+readme.md
+t/author/manifest.t
+t/author/pod-coverage.t
+t/author/pod.t
+t/install.t
+t/unit/01-get-data.t
+t/unit/02-process-once.t
+t/unit/03-encode-data.t
+t/unit/04-padding.t
+t/unit/05-html.t
+t/unit/06-transpose.t
+t/unit/07-reverse.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
     AUTHOR           => q{Jeff Anderson <jeffa@cpan.org>},
     VERSION_FROM     => 'lib/Spreadsheet/HTML.pm',
     ABSTRACT_FROM    => 'lib/Spreadsheet/HTML.pm',
-    LICENSE          => 'Artistic_2_0',
+    LICENSE          => 'artistic_2',
     PL_FILES         => {},
     MIN_PERL_VERSION => 5.006,
     CONFIGURE_REQUIRES => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,20 @@ if ($mm_ver =~ /_/) {
     die $@ if $@;
 }
 
+my @REQUIRES = (
+    'strict'            => 0,
+    'warnings'          => 0,
+    'Data::Dumper'      => 0,
+    'HTML::Entities'    => 0,
+    'Math::Matrix'      => 0,
+);
+
+my @TEST_REQUIRES = (
+    'Test::More'        => 0.88,
+);
+
+push(@REQUIRES, @TEST_REQUIRES) if $mm_ver < 6.64;
+
 WriteMakefile(
     NAME             => 'Spreadsheet::HTML',
     AUTHOR           => q{Jeff Anderson <jeffa@cpan.org>},
@@ -18,17 +32,23 @@ WriteMakefile(
     LICENSE          => 'artistic_2',
     PL_FILES         => {},
     MIN_PERL_VERSION => 5.006,
-    CONFIGURE_REQUIRES => {
-        'ExtUtils::MakeMaker' => 0,
-    },
-    BUILD_REQUIRES => {
-        'Test::More'        => 0,
-        'HTML::Entities'    => 0,
-        'Math::Matrix'      => 0,
-    },
-    PREREQ_PM => { },
+
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Spreadsheet-HTML-*' },
+
+    PREREQ_PM   => { @REQUIRES },
+
+    ($mm_ver >= 6.52
+        ? (CONFIGURE_REQUIRES => {
+                'ExtUtils::MakeMaker' => 0,
+          })
+        : ()
+    ),
+
+    ($mm_ver >= 6.64
+        ? (TEST_REQUIRES => { @TEST_REQUIRES })
+        : ()
+    ),
 
     ($mm_ver <= 6.45
         ? ()

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,6 +3,13 @@ use strict;
 use warnings FATAL => 'all';
 use ExtUtils::MakeMaker;
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) {
+    # developer release
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 WriteMakefile(
     NAME             => 'Spreadsheet::HTML',
     AUTHOR           => q{Jeff Anderson <jeffa@cpan.org>},
@@ -22,4 +29,19 @@ WriteMakefile(
     PREREQ_PM => { },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Spreadsheet-HTML-*' },
+
+    ($mm_ver <= 6.45
+        ? ()
+        : (META_MERGE => {
+            'meta-spec' => { version => 2 },
+            resources => {
+                repository  => {
+                    type => 'git',
+                    web  => 'https://github.com/jeffa/Spreadsheet-HTML',
+                    url  => 'https://github.com/jeffa/Spreadsheet-HTML.git',
+                },
+            },
+          })
+    ),
+
 );


### PR DESCRIPTION
Hi,

I've added your github repo to the dist's metadata. This means it will now turn up in the sidebar on MetaCPAN, and other tools will be able to find it too. For example, having this will make it a candidate for assigning to someone in the [CPAN Pull Request Challenge](http://cpan-prc.org).

I did some other things too:
- The Makefile was setting license to 'Artistic_2_0', but it should be 'artistic_2'
- Set the prereqs fields appropriately depending on the local version of ExtUtils::MakeMaker
- Added a MANIFEST file, so "perl Makefile.PL; make dist" will now work
- Tweaked the format of the Changes file

Cheers,
Neil
